### PR TITLE
fix: unblock pub publish (silence unused_element warning)

### DIFF
--- a/universal_video_controls/lib/universal_video_controls/src/controls/cupertino.dart
+++ b/universal_video_controls/lib/universal_video_controls/src/controls/cupertino.dart
@@ -22,7 +22,9 @@ Widget CupertinoVideoControls(VideoControlsState state) {
   );
 }
 
-/// [MaterialDesktopVideoControlsThemeData] available in this [context].
+/// [CupertinoVideoControlsThemeData] available in this [context].
+// Kept for parity with the Material controls; not currently referenced.
+// ignore: unused_element
 CupertinoVideoControlsThemeData _theme(BuildContext context) =>
     FullscreenInheritedWidget.maybeOf(context) == null
         ? CupertinoVideoControlsTheme.maybeOf(context)?.normal ??


### PR DESCRIPTION
The `universal_video_controls-v2.0.0` publish run failed at `pub publish`'s validation step because `dart analyze` reports a **warning** for the unused `_theme(context)` helper in `cupertino.dart`, and pub treats warnings as blocking (exit 65).

Per request, the helper is kept (for parity with the Material controls) and the lint is suppressed with `// ignore: unused_element`. Verified locally: the package's `lib/` now reports no analyzer warnings/errors and `flutter pub publish --dry-run` no longer flags it.

This is a pre-existing issue, surfaced only now during the first publish. After merge, the `universal_video_controls-v2.0.0` tag will be recreated to re-trigger publishing.