### PR TITLE
ci: fix web and windows example builds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
 
       # Step to build Flutter Web
       - name: Build Flutter Web
-        run: flutter build web --release --base-href "/universal_video_controls/" --web-renderer canvaskit
+        run: flutter build web --release --base-href "/universal_video_controls/"
 
       # Step to move the Flutter Web build to a temporary directory
       - name: Move Web Build to Temporary Directory

--- a/universal_video_controls/windows/CMakeLists.txt
+++ b/universal_video_controls/windows/CMakeLists.txt
@@ -70,7 +70,7 @@ enable_testing()
 include(FetchContent)
 FetchContent_Declare(
   googletest
-  URL https://github.com/google/googletest/archive/release-1.11.0.zip
+  URL https://github.com/google/googletest/archive/refs/tags/v1.15.2.zip
 )
 # Prevent overriding the parent project's compiler/linker settings
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)


### PR DESCRIPTION
Fixes the two remaining red jobs in `deploy.yml`. Both are pre-existing toolchain rot (unpinned latest stable Flutter / CMake), unrelated to the SPM migration.

## Web
`flutter build web ... --web-renderer canvaskit` → `Could not find an option named "--web-renderer"`. The flag was **removed in Flutter 3.29**; CanvasKit is the default renderer now. Dropped the flag.
✅ Verified locally: `flutter build web --release --base-href "/universal_video_controls/"` succeeds.

## Windows
googletest `release-1.11.0` fails on the runner's CMake 4.x: *"Compatibility with CMake < 3.5 has been removed."* Bumped the bundled googletest to **v1.15.2** (its `cmake_minimum_required` is 3.13).
⏳ Can't build Windows locally (on macOS) — relying on this PR's CI to verify.

Let the PR's `deploy.yml` run confirm both jobs are green before merging.