### PR TITLE
chore: salvage good parts of #7 (example init guards, video_player bump, melos format)

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -8,6 +8,8 @@ scripts:
     exec: dart analyze .
   pub_get:
     run: melos exec -- flutter pub get
+  format:
+    run: melos exec -- dart format . && dart fix --apply .
   upgrade_major_versions:
     run: |
       melos exec -- flutter pub upgrade --major-versions

--- a/universal_video_controls/example/lib/tests/02.tabs_test.dart
+++ b/universal_video_controls/example/lib/tests/02.tabs_test.dart
@@ -89,6 +89,11 @@ class TabViewState extends State<TabView> {
 
   @override
   Widget build(BuildContext context) {
+    if (!_isInitialized) {
+      return const Center(
+        child: CircularProgressIndicator(),
+      );
+    }
     return VideoControls(
       player: VideoPlayerControlsWrapper(_controller),
       controls: NoVideoControls,

--- a/universal_video_controls/example/lib/tests/03.stress_test.dart
+++ b/universal_video_controls/example/lib/tests/03.stress_test.dart
@@ -73,14 +73,16 @@ class _StressTestScreenState extends State<StressTestScreen> {
       appBar: AppBar(
         title: const Text('Video Player'),
       ),
-      body: GridView.extent(
-        maxCrossAxisExtent: 480.0,
-        padding: const EdgeInsets.all(16.0),
-        mainAxisSpacing: 16.0,
-        crossAxisSpacing: 16.0,
-        childAspectRatio: 16.0 / 9.0,
-        children: children,
-      ),
+      body: !_isInitialized
+          ? const Center(child: CircularProgressIndicator())
+          : GridView.extent(
+              maxCrossAxisExtent: 480.0,
+              padding: const EdgeInsets.all(16.0),
+              mainAxisSpacing: 16.0,
+              crossAxisSpacing: 16.0,
+              childAspectRatio: 16.0 / 9.0,
+              children: children,
+            ),
     );
   }
 }

--- a/universal_video_controls/example/lib/tests/07.video_view_parameters.dart
+++ b/universal_video_controls/example/lib/tests/07.video_view_parameters.dart
@@ -173,57 +173,61 @@ class _VideoViewParametersScreenState extends State<VideoViewParametersScreen> {
           ),
         ],
       ),
-      body: SizedBox.expand(
-        child: horizontal
-            ? Row(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  Expanded(
-                    flex: 3,
-                    child: Container(
-                      alignment: Alignment.center,
-                      child: Column(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          Expanded(
-                            child: Card(
-                              elevation: 8.0,
-                              clipBehavior: Clip.antiAlias,
-                              margin: const EdgeInsets.all(32.0),
-                              child: VideoControls(
-                                key: key,
-                                fit: fit,
-                                player: VideoPlayerControlsWrapper(_controller),
-                              ),
+      body: !_isInitialized
+          ? const Center(child: CircularProgressIndicator())
+          : SizedBox.expand(
+              child: horizontal
+                  ? Row(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        Expanded(
+                          flex: 3,
+                          child: Container(
+                            alignment: Alignment.center,
+                            child: Column(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Expanded(
+                                  child: Card(
+                                    elevation: 8.0,
+                                    clipBehavior: Clip.antiAlias,
+                                    margin: const EdgeInsets.all(32.0),
+                                    child: VideoControls(
+                                      key: key,
+                                      fit: fit,
+                                      player: VideoPlayerControlsWrapper(
+                                          _controller),
+                                    ),
+                                  ),
+                                ),
+                                const SizedBox(height: 32.0),
+                              ],
                             ),
                           ),
-                          const SizedBox(height: 32.0),
-                        ],
-                      ),
+                        ),
+                        const VerticalDivider(width: 1.0, thickness: 1.0),
+                        Expanded(
+                          flex: 1,
+                          child: ListView(
+                            children: items,
+                          ),
+                        ),
+                      ],
+                    )
+                  : ListView(
+                      children: [
+                        VideoControls(
+                          key: key,
+                          fit: fit,
+                          player: VideoPlayerControlsWrapper(_controller),
+                          width: MediaQuery.of(context).size.width,
+                          height:
+                              MediaQuery.of(context).size.width * 9.0 / 16.0,
+                        ),
+                        ...items,
+                      ],
                     ),
-                  ),
-                  const VerticalDivider(width: 1.0, thickness: 1.0),
-                  Expanded(
-                    flex: 1,
-                    child: ListView(
-                      children: items,
-                    ),
-                  ),
-                ],
-              )
-            : ListView(
-                children: [
-                  VideoControls(
-                    key: key,
-                    fit: fit,
-                    player: VideoPlayerControlsWrapper(_controller),
-                    width: MediaQuery.of(context).size.width,
-                    height: MediaQuery.of(context).size.width * 9.0 / 16.0,
-                  ),
-                  ...items,
-                ],
-              ),
-      ),
+            ),
     );
   }
 }

--- a/universal_video_controls/example/lib/tests/08.custom_mobile_controls.dart
+++ b/universal_video_controls/example/lib/tests/08.custom_mobile_controls.dart
@@ -123,54 +123,57 @@ class _CustomMobileControlsState extends State<CustomMobileControls> {
             ),
           ],
         ),
-        body: SizedBox.expand(
-          child: horizontal
-              ? Row(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    Expanded(
-                      flex: 3,
-                      child: Container(
-                        alignment: Alignment.center,
-                        child: Column(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            Expanded(
-                              child: Card(
-                                elevation: 8.0,
-                                clipBehavior: Clip.antiAlias,
-                                margin: const EdgeInsets.all(32.0),
-                                child: VideoControls(
-                                  player:
-                                      VideoPlayerControlsWrapper(_controller),
-                                ),
+        body: !_isInitialized
+            ? Center(child: CircularProgressIndicator())
+            : SizedBox.expand(
+                child: horizontal
+                    ? Row(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          Expanded(
+                            flex: 3,
+                            child: Container(
+                              alignment: Alignment.center,
+                              child: Column(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  Expanded(
+                                    child: Card(
+                                      elevation: 8.0,
+                                      clipBehavior: Clip.antiAlias,
+                                      margin: const EdgeInsets.all(32.0),
+                                      child: VideoControls(
+                                        player: VideoPlayerControlsWrapper(
+                                            _controller),
+                                      ),
+                                    ),
+                                  ),
+                                  const SizedBox(height: 32.0),
+                                ],
                               ),
                             ),
-                            const SizedBox(height: 32.0),
-                          ],
-                        ),
+                          ),
+                          const VerticalDivider(width: 1.0, thickness: 1.0),
+                          Expanded(
+                            flex: 1,
+                            child: ListView(
+                              children: items,
+                            ),
+                          ),
+                        ],
+                      )
+                    : ListView(
+                        children: [
+                          VideoControls(
+                            player: VideoPlayerControlsWrapper(_controller),
+                            width: MediaQuery.of(context).size.width,
+                            height:
+                                MediaQuery.of(context).size.width * 9.0 / 16.0,
+                          ),
+                          ...items,
+                        ],
                       ),
-                    ),
-                    const VerticalDivider(width: 1.0, thickness: 1.0),
-                    Expanded(
-                      flex: 1,
-                      child: ListView(
-                        children: items,
-                      ),
-                    ),
-                  ],
-                )
-              : ListView(
-                  children: [
-                    VideoControls(
-                      player: VideoPlayerControlsWrapper(_controller),
-                      width: MediaQuery.of(context).size.width,
-                      height: MediaQuery.of(context).size.width * 9.0 / 16.0,
-                    ),
-                    ...items,
-                  ],
-                ),
-        ),
+              ),
       ),
     );
   }

--- a/universal_video_controls/example/lib/tests/09.custom_desktop_controls.dart
+++ b/universal_video_controls/example/lib/tests/09.custom_desktop_controls.dart
@@ -127,54 +127,57 @@ class _CustomDesktopControlsState extends State<CustomDesktopControls> {
             ),
           ],
         ),
-        body: SizedBox.expand(
-          child: horizontal
-              ? Row(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    Expanded(
-                      flex: 3,
-                      child: Container(
-                        alignment: Alignment.center,
-                        child: Column(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            Expanded(
-                              child: Card(
-                                elevation: 8.0,
-                                clipBehavior: Clip.antiAlias,
-                                margin: const EdgeInsets.all(32.0),
-                                child: VideoControls(
-                                  player:
-                                      VideoPlayerControlsWrapper(_controller),
-                                ),
+        body: !_isInitialized
+            ? const Center(child: CircularProgressIndicator())
+            : SizedBox.expand(
+                child: horizontal
+                    ? Row(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          Expanded(
+                            flex: 3,
+                            child: Container(
+                              alignment: Alignment.center,
+                              child: Column(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  Expanded(
+                                    child: Card(
+                                      elevation: 8.0,
+                                      clipBehavior: Clip.antiAlias,
+                                      margin: const EdgeInsets.all(32.0),
+                                      child: VideoControls(
+                                        player: VideoPlayerControlsWrapper(
+                                            _controller),
+                                      ),
+                                    ),
+                                  ),
+                                  const SizedBox(height: 32.0),
+                                ],
                               ),
                             ),
-                            const SizedBox(height: 32.0),
-                          ],
-                        ),
+                          ),
+                          const VerticalDivider(width: 1.0, thickness: 1.0),
+                          Expanded(
+                            flex: 1,
+                            child: ListView(
+                              children: items,
+                            ),
+                          ),
+                        ],
+                      )
+                    : ListView(
+                        children: [
+                          VideoControls(
+                            player: VideoPlayerControlsWrapper(_controller),
+                            width: MediaQuery.of(context).size.width,
+                            height:
+                                MediaQuery.of(context).size.width * 9.0 / 16.0,
+                          ),
+                          ...items,
+                        ],
                       ),
-                    ),
-                    const VerticalDivider(width: 1.0, thickness: 1.0),
-                    Expanded(
-                      flex: 1,
-                      child: ListView(
-                        children: items,
-                      ),
-                    ),
-                  ],
-                )
-              : ListView(
-                  children: [
-                    VideoControls(
-                      player: VideoPlayerControlsWrapper(_controller),
-                      width: MediaQuery.of(context).size.width,
-                      height: MediaQuery.of(context).size.width * 9.0 / 16.0,
-                    ),
-                    ...items,
-                  ],
-                ),
-        ),
+              ),
       ),
     );
   }

--- a/universal_video_controls/example/lib/tests/10.custom_adaptive_controls.dart
+++ b/universal_video_controls/example/lib/tests/10.custom_adaptive_controls.dart
@@ -149,54 +149,58 @@ class _CustomAdaptiveControlsState extends State<CustomAdaptiveControls> {
               ),
             ],
           ),
-          body: SizedBox.expand(
-            child: horizontal
-                ? Row(
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    children: [
-                      Expanded(
-                        flex: 3,
-                        child: Container(
-                          alignment: Alignment.center,
-                          child: Column(
-                            mainAxisSize: MainAxisSize.min,
-                            children: [
-                              Expanded(
-                                child: Card(
-                                  elevation: 8.0,
-                                  clipBehavior: Clip.antiAlias,
-                                  margin: const EdgeInsets.all(32.0),
-                                  child: VideoControls(
-                                    player:
-                                        VideoPlayerControlsWrapper(_controller),
-                                  ),
+          body: !_isInitialized
+              ? const Center(child: CircularProgressIndicator())
+              : SizedBox.expand(
+                  child: horizontal
+                      ? Row(
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          children: [
+                            Expanded(
+                              flex: 3,
+                              child: Container(
+                                alignment: Alignment.center,
+                                child: Column(
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: [
+                                    Expanded(
+                                      child: Card(
+                                        elevation: 8.0,
+                                        clipBehavior: Clip.antiAlias,
+                                        margin: const EdgeInsets.all(32.0),
+                                        child: VideoControls(
+                                          player: VideoPlayerControlsWrapper(
+                                              _controller),
+                                        ),
+                                      ),
+                                    ),
+                                    const SizedBox(height: 32.0),
+                                  ],
                                 ),
                               ),
-                              const SizedBox(height: 32.0),
-                            ],
-                          ),
+                            ),
+                            const VerticalDivider(width: 1.0, thickness: 1.0),
+                            Expanded(
+                              flex: 1,
+                              child: ListView(
+                                children: items,
+                              ),
+                            ),
+                          ],
+                        )
+                      : ListView(
+                          children: [
+                            VideoControls(
+                              player: VideoPlayerControlsWrapper(_controller),
+                              width: MediaQuery.of(context).size.width,
+                              height: MediaQuery.of(context).size.width *
+                                  9.0 /
+                                  16.0,
+                            ),
+                            ...items,
+                          ],
                         ),
-                      ),
-                      const VerticalDivider(width: 1.0, thickness: 1.0),
-                      Expanded(
-                        flex: 1,
-                        child: ListView(
-                          children: items,
-                        ),
-                      ),
-                    ],
-                  )
-                : ListView(
-                    children: [
-                      VideoControls(
-                        player: VideoPlayerControlsWrapper(_controller),
-                        width: MediaQuery.of(context).size.width,
-                        height: MediaQuery.of(context).size.width * 9.0 / 16.0,
-                      ),
-                      ...items,
-                    ],
-                  ),
-          ),
+                ),
         ),
       ),
     );

--- a/universal_video_controls/example/lib/tests/11.full_screen_player.dart
+++ b/universal_video_controls/example/lib/tests/11.full_screen_player.dart
@@ -50,6 +50,11 @@ class _FullScreenPlayerState extends State<FullScreenPlayer> {
 
   @override
   Widget build(BuildContext context) {
+    if (!_isInitialized) {
+      return const Center(
+        child: CircularProgressIndicator(),
+      );
+    }
     return // Wrap [Video] widget with [MaterialVideoControlsTheme].
         MaterialVideoControlsTheme(
             normal: MaterialVideoControlsThemeData(

--- a/universal_video_controls/example/lib/tests/12.settings_button.dart
+++ b/universal_video_controls/example/lib/tests/12.settings_button.dart
@@ -68,6 +68,12 @@ class _CustomDesktopSettingsButtonState
 
   @override
   Widget build(BuildContext context) {
+    if (!_isInitialized) {
+      return const Center(
+        child: CircularProgressIndicator(),
+      );
+    }
+
     final horizontal =
         MediaQuery.of(context).size.width > MediaQuery.of(context).size.height;
     return MaterialVideoControlsTheme(

--- a/universal_video_controls/example/pubspec.lock
+++ b/universal_video_controls/example/pubspec.lock
@@ -29,10 +29,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -227,26 +227,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.18.0"
   package_info_plus:
     dependency: transitive
     description:
@@ -512,10 +512,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.11"
   typed_data:
     dependency: transitive
     description:
@@ -538,7 +538,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.1.0"
+    version: "2.0.0"
   universal_video_controls_video_player:
     dependency: "direct main"
     description:
@@ -675,5 +675,5 @@ packages:
     source: hosted
     version: "6.6.1"
 sdks:
-  dart: ">=3.8.0 <4.0.0"
+  dart: ">=3.10.0-0 <4.0.0"
   flutter: ">=3.29.0"

--- a/universal_video_controls_video_player/lib/universal_video_controls_video_player.dart
+++ b/universal_video_controls_video_player/lib/universal_video_controls_video_player.dart
@@ -1,4 +1,4 @@
-library universal_video_controls_video_player;
+library;
 
 import 'dart:async';
 import 'package:flutter/material.dart';

--- a/universal_video_controls_video_player/pubspec.yaml
+++ b/universal_video_controls_video_player/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   universal_video_controls: ^1.0.10
-  video_player: ^2.4.5
+  video_player: ^2.7.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Reapplies the still-valuable, non-redundant parts of the stale **#7 ("Fix pub points")** cleanly on top of current main, then #7 can be closed.

## Included
- **Example init guards** (8 test screens): guard `build()` with `if (!_isInitialized) return CircularProgressIndicator()`. Uses the previously-unused `_isInitialized` fields → clears their `unused_field` warnings and avoids rendering uninitialized controllers.
- **universal_video_controls_video_player**: `library <name>;` → `library;` (fixes `unnecessary_library_name`); bump `video_player ^2.4.5 → ^2.7.2`.
- **melos.yaml**: add a `format` convenience script.

✅ Verified: `dart analyze` clean (example `unused_field` warnings gone; `_video_player` clean), deps resolve.

## Deliberately omitted from #7
- `--web-renderer` removal and `cupertino.dart` `unused_element` ignore — **already on main** (would conflict).
- A committed generated `GeneratedPluginRegistrant.swift` and a stray blank line in `abstract.dart` (noise/regression).

## Note
These don't change published library behavior much, but to realize the pub-points/score gain you'd publish new versions (tag `universal_video_controls-v*` / `universal_video_controls_video_player-v*`). Versions are left unbumped for you to decide.