### PR TITLE
chore: release universal_video_controls 2.0.1 + _video_player 1.0.8

### DIFF
--- a/universal_video_controls/CHANGELOG.md
+++ b/universal_video_controls/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.1
+
+- chore: guard example screens with an initialization check (fixes analyzer `unused_field` warnings; avoids rendering uninitialized controllers).
+- chore: add a `format` melos script.
+
 ## 2.0.0
 
 - feat: add Swift Package Manager support for iOS and macOS (CocoaPods still supported).

--- a/universal_video_controls/pubspec.yaml
+++ b/universal_video_controls/pubspec.yaml
@@ -1,6 +1,6 @@
 name: universal_video_controls
 description: "Video player controls for all platforms based on media_kit controls but with abstraction to allow any other player to work using it (video_player is supported)"
-version: 2.0.0
+version: 2.0.1
 homepage: https://github.com/abdelaziz-mahdy/universal_video_controls
 
 environment:

--- a/universal_video_controls_video_player/CHANGELOG.md
+++ b/universal_video_controls_video_player/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.8
+
+- chore: remove unnecessary library name (`library;`) to fix the `unnecessary_library_name` lint.
+- chore: bump `video_player` constraint to `^2.7.2`.
+
 ## 1.0.7
 
 - Implement update position forcer to make subtitles show on time (instead of video_player 500 milliseconds delay) it now has a delay of 100 milliseconds

--- a/universal_video_controls_video_player/pubspec.yaml
+++ b/universal_video_controls_video_player/pubspec.yaml
@@ -1,6 +1,6 @@
 name: universal_video_controls_video_player
 description: Interface for video_player to work with universal_video_controls
-version: 1.0.7
+version: 1.0.8
 homepage: https://github.com/abdelaziz-mahdy/universal_video_controls
 
 environment:


### PR DESCRIPTION
Version bumps + CHANGELOG entries so the analyzer cleanups from #16 ship as releases.

- **universal_video_controls** 2.0.0 → **2.0.1** (example init guards, melos format script)
- **universal_video_controls_video_player** 1.0.7 → **1.0.8** (`library;` lint fix, `video_player ^2.7.2`)

After merge I'll tag `universal_video_controls-v2.0.1` and `universal_video_controls_video_player-v1.0.8` to trigger OIDC publishing. The latter is _video_player's first automated publish.